### PR TITLE
FEATURE: Use Flow folder for Google Storage temp files

### DIFF
--- a/Classes/StorageFactory.php
+++ b/Classes/StorageFactory.php
@@ -28,6 +28,12 @@ class StorageFactory
     protected $credentialProfiles;
 
     /**
+     * @Flow\Inject
+     * @var \TYPO3\Flow\Utility\Environment
+     */
+    protected $environment;
+
+    /**
      * Creates a new Storage instance and authenticates agains the Google API
      *
      * @param string $credentialsProfileName
@@ -57,7 +63,10 @@ class StorageFactory
             $privateKey
         );
 
+        $temporaryTargetPathAndFilename = $this->environment->getPathToTemporaryDirectory() . uniqid('Flownative_Google_CloudStorage_Temp_');
+       
         $googleClient = new \Google_Client();
+        $googleClient->setClassConfig('Google_Cache_File', 'directory',  $temporaryTargetPathAndFilename);
         $googleClient->setAssertionCredentials($credentials);
         if ($googleClient->isAccessTokenExpired()) {
             $googleClient->getRefreshToken();

--- a/Classes/StorageFactory.php
+++ b/Classes/StorageFactory.php
@@ -28,10 +28,10 @@ class StorageFactory
     protected $credentialProfiles;
 
     /**
-     * @Flow\Inject
-     * @var \TYPO3\Flow\Utility\Environment
-     */
-    protected $environment;
+     * @Flow\Inject
+     * @var \TYPO3\Flow\Utility\Environment
+     */
+    protected $environment;
 
     /**
      * Creates a new Storage instance and authenticates agains the Google API
@@ -66,7 +66,7 @@ class StorageFactory
         $temporaryTargetPathAndFilename = $this->environment->getPathToTemporaryDirectory() . 'Flownative_Google_CloudStorage_Temp';
        
         $googleClient = new \Google_Client();
-        $googleClient->setClassConfig('Google_Cache_File', 'directory',  $temporaryTargetPathAndFilename);
+        $googleClient->setClassConfig('Google_Cache_File', 'directory',$temporaryTargetPathAndFilename);
         $googleClient->setAssertionCredentials($credentials);
         if ($googleClient->isAccessTokenExpired()) {
             $googleClient->getRefreshToken();

--- a/Classes/StorageFactory.php
+++ b/Classes/StorageFactory.php
@@ -63,7 +63,7 @@ class StorageFactory
             $privateKey
         );
 
-        $temporaryTargetPathAndFilename = $this->environment->getPathToTemporaryDirectory() . uniqid('Flownative_Google_CloudStorage_Temp_');
+        $temporaryTargetPathAndFilename = $this->environment->getPathToTemporaryDirectory() . 'Flownative_Google_CloudStorage_Temp';
        
         $googleClient = new \Google_Client();
         $googleClient->setClassConfig('Google_Cache_File', 'directory',  $temporaryTargetPathAndFilename);


### PR DESCRIPTION
The GoogleCloudStorage tries to save some temporary files in the server
temporary directory. Working with docker might generate some permission
errors. This feature fixes this issue and lets the Google API use the Flow
folder structure.
