### PR TITLE
BUGFIX: Set mimeType explicitly

### DIFF
--- a/Classes/Command/GcsCommandController.php
+++ b/Classes/Command/GcsCommandController.php
@@ -52,7 +52,8 @@ class GcsCommandController extends CommandController
 
         $postBody = [
             'data' => 'test',
-            'uploadType' => 'media'
+            'uploadType' => 'media',
+            'mimeType' => 'text/plain'
         ];
 
         $this->outputLine('Writing test object into bucket (%s) ...', [$bucket]);

--- a/Classes/GcsStorage.php
+++ b/Classes/GcsStorage.php
@@ -220,7 +220,8 @@ class GcsStorage implements WritableStorageInterface
         $storageObject->setName($this->keyPrefix . $sha1Hash);
         $storageObject->setSize($resource->getFileSize());
 
-        $this->storageService->objects->insert($this->bucketName, $storageObject, ['data' => $content, 'uploadType' => 'media']);
+        $this->storageService->objects->insert($this->bucketName, $storageObject,
+            ['data' => $content, 'uploadType' => 'media', 'mimeType' => $resource->getMediaType()]);
 
         return $resource;
     }
@@ -270,7 +271,8 @@ class GcsStorage implements WritableStorageInterface
 
         $postBody = [
             'data' => file_get_contents($newSourcePathAndFilename),
-            'uploadType' => 'media'
+            'uploadType' => 'media',
+            'mimeType' => $resource->getMediaType()
         ];
 
         $this->storageService->objects->insert($this->bucketName, $storageObject, $postBody);
@@ -447,7 +449,7 @@ class GcsStorage implements WritableStorageInterface
             $storageObject->setName($this->keyPrefix . $sha1Hash);
             $storageObject->setSize($resource->getFileSize());
 
-            $this->storageService->objects->insert($this->bucketName, $storageObject, ['data' => file_get_contents($temporaryPathAndFilename), 'uploadType' => 'media']);
+            $this->storageService->objects->insert($this->bucketName, $storageObject, ['data' => file_get_contents($temporaryPathAndFilename), 'uploadType' => 'media', 'mimeType' => $resource->getMediaType()]);
             $this->systemLogger->log(sprintf('Successfully imported resource as object "%s" into bucket "%s" with MD5 hash "%s"', $sha1Hash, $this->bucketName, $resource->getMd5() ?: 'unknown'), LOG_INFO);
         } else {
             $this->systemLogger->log(sprintf('Did not import resource as object "%s" into bucket "%s" because that object already existed.', $sha1Hash, $this->bucketName), LOG_INFO);

--- a/Classes/GcsTarget.php
+++ b/Classes/GcsTarget.php
@@ -203,7 +203,8 @@ class GcsTarget implements TargetInterface
                 $storageObject->setCacheControl('public, max-age=1209600');
 
                 $parameters = [
-                    'destinationPredefinedAcl' => 'publicRead'
+                    'destinationPredefinedAcl' => 'publicRead',
+                    'mimeType' => $object->getMediaType()
                 ];
                 try {
                     $this->storageService->objects->copy($storageBucketName, $storage->getKeyPrefix() . $object->getSha1(), $this->bucketName, $objectName, $storageObject, $parameters);
@@ -268,7 +269,8 @@ class GcsTarget implements TargetInterface
             $storageObject->setCacheControl('public, max-age=1209600');
 
             $parameters = [
-                'destinationPredefinedAcl' => 'publicRead'
+                'destinationPredefinedAcl' => 'publicRead',
+                'mimeType' => $resource->getMediaType()
             ];
             try {
                 $this->storageService->objects->copy($storage->getBucketName(), $storage->getKeyPrefix() . $resource->getSha1(), $this->bucketName, $objectName, $storageObject, $parameters);
@@ -345,7 +347,8 @@ class GcsTarget implements TargetInterface
             $parameters = [
                 'data' => stream_get_contents($sourceStream),
                 'uploadType' => 'media',
-                'predefinedAcl' => 'publicRead'
+                'predefinedAcl' => 'publicRead',
+                'mimeType' => $metaData->getMediaType()
             ];
 
             $this->storageService->objects->insert($this->bucketName, $storageObject, $parameters);


### PR DESCRIPTION
The mimeType must be set explicitly to the same value that is specified
in the ContentType property. Otherwhise Google Cloud Storage will complain
that the content type specified in the upload is different from the content
type specified for the file.

Since I've not done that much pull-requests so far, please tell me if I need to do anything differently.
I've tested the changes in my Kubernetes setup as well as locally and got no errors when uploading files.