### PR TITLE
BUGFIX: Fix Issue Public URLs with invalid spaces.

### DIFF
--- a/Classes/GcsTarget.php
+++ b/Classes/GcsTarget.php
@@ -241,6 +241,7 @@ class GcsTarget implements TargetInterface
      */
     public function getPublicStaticResourceUri($relativePathAndFilename)
     {
+	    $relativePathAndFilename = $this->encodeRelativePathAndFilenameForUri($relativePathAndFilename);
         return $this->storageService->objects->get($this->bucketName, $this->keyPrefix . $relativePathAndFilename)->getMediaLink();
     }
 
@@ -317,10 +318,11 @@ class GcsTarget implements TargetInterface
      */
     public function getPublicPersistentResourceUri(PersistentResource $resource)
     {
+	    $relativePathAndFilename = $this->encodeRelativePathAndFilenameForUri($this->getRelativePublicationPathAndFilename($resource));
         if ($this->baseUri != '') {
-            return $this->baseUri . $this->getRelativePublicationPathAndFilename($resource);
+            return $this->baseUri . $relativePathAndFilename;
         } else {
-            return $this->storageService->objects->get($this->bucketName, $this->keyPrefix . $this->getRelativePublicationPathAndFilename($resource))->getMediaLink();
+            return $this->storageService->objects->get($this->bucketName, $this->keyPrefix . $relativePathAndFilename)->getMediaLink();
         }
     }
 
@@ -377,7 +379,7 @@ class GcsTarget implements TargetInterface
         } else {
             $pathAndFilename = $object->getSha1() . '/' . $object->getFilename();
         }
-        return $this->encodeRelativePathAndFilenameForUri($pathAndFilename);
+	    return $pathAndFilename;
     }
 
     /**

--- a/Classes/GcsTarget.php
+++ b/Classes/GcsTarget.php
@@ -241,7 +241,7 @@ class GcsTarget implements TargetInterface
      */
     public function getPublicStaticResourceUri($relativePathAndFilename)
     {
-	    $relativePathAndFilename = $this->encodeRelativePathAndFilenameForUri($relativePathAndFilename);
+        $relativePathAndFilename = $this->encodeRelativePathAndFilenameForUri($relativePathAndFilename);
         return $this->storageService->objects->get($this->bucketName, $this->keyPrefix . $relativePathAndFilename)->getMediaLink();
     }
 
@@ -318,7 +318,7 @@ class GcsTarget implements TargetInterface
      */
     public function getPublicPersistentResourceUri(PersistentResource $resource)
     {
-	    $relativePathAndFilename = $this->encodeRelativePathAndFilenameForUri($this->getRelativePublicationPathAndFilename($resource));
+        $relativePathAndFilename = $this->encodeRelativePathAndFilenameForUri($this->getRelativePublicationPathAndFilename($resource));
         if ($this->baseUri != '') {
             return $this->baseUri . $relativePathAndFilename;
         } else {
@@ -379,7 +379,7 @@ class GcsTarget implements TargetInterface
         } else {
             $pathAndFilename = $object->getSha1() . '/' . $object->getFilename();
         }
-	    return $pathAndFilename;
+        return $pathAndFilename;
     }
 
     /**


### PR DESCRIPTION
Use encoding only for the uri requests, not for the upload filename. Otherwise the `%` gets
escaped again from the google cloud storage and the resource will not be available.