### PR TITLE
Allow publishCollection to run even if errors for single resources occur.

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -12,3 +12,4 @@ Flownative:
             # the "privateKeyP12" option wins.
             privateKeyP12PathAndFilename: 'Data/Secrets/MyGoogleProject-abc123457def.p12'
             privateKeyP12Base64Encoded: ''
+      continuesFailureLimit: 50


### PR DESCRIPTION
allow to continue the publication even if errors occur. To not run the full publication if there is a system error there is a option to only accept a limited amount of continues publication tries. The default settings is currently to 50 failure in a row before the complete collection publication get's aborted.