### PR TITLE
Fix wrong parameters on getCurrentBucket()->object() call

### DIFF
--- a/Classes/GcsStorage.php
+++ b/Classes/GcsStorage.php
@@ -349,7 +349,7 @@ class GcsStorage implements WritableStorageInterface
     public function getStreamByResourcePath($relativePath)
     {
         try {
-            $stream = $this->getCurrentBucket()->object($this->bucketName, $this->keyPrefix . ltrim($relativePath, '/'))->downloadAsStream();
+            $stream = $this->getCurrentBucket()->object($this->keyPrefix . ltrim($relativePath, '/'))->downloadAsStream();
             return StreamWrapper::getResource($stream);
         } catch (\Exception $e) {
             if ($e instanceof NotFoundException) {


### PR DESCRIPTION
When this was adjusted from google/apiclient to google/cloud-storage
in 2842c7864828f475f11bab1008d0d662b7f0b06f the signature for that call changed from

```
 * @param string $bucket Name of the bucket in which the object resides.
 * @param string $object Name of the object. For information about how to URL
 * encode object names to be path safe, see Encoding URI Path Parts.
 * @param array $optParams Optional parameters
```

to

```
 * @param string $name The name of the object to request.
 * @param array $options [optional]
```