### PR TITLE
BUGFIX: Detect Content-Type in GcsStorage

### DIFF
--- a/Classes/GcsStorage.php
+++ b/Classes/GcsStorage.php
@@ -237,6 +237,14 @@ class GcsStorage implements WritableStorageInterface
         $resource->setSha1($sha1Hash);
         $resource->setMd5($md5Hash);
 
+        if (
+            class_exists('\finfo')
+            && ($finfo = new \finfo(FILEINFO_MIME_TYPE))
+            && ($mediaType = $finfo->buffer($content))
+        ) {
+            $resource->setMediaType($mediaType);
+        }
+
         $this->getCurrentBucket()->upload($content, [
             'name' => $this->keyPrefix . $sha1Hash,
             'metadata' => [
@@ -428,6 +436,13 @@ class GcsStorage implements WritableStorageInterface
         $resource->setCollectionName($collectionName);
         $resource->setSha1($sha1Hash);
         $resource->setMd5($md5Hash);
+
+        if (
+            function_exists('mime_content_type')
+            && $mediaType = mime_content_type($temporaryPathAndFilename)
+        ) {
+            $resource->setMediaType($mediaType);
+        }
 
         $bucket = $this->getCurrentBucket();
         if (!$bucket->object($this->keyPrefix . $sha1Hash)->exists()) {

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,9 @@
         "ext-pdo": "*",
         "ext-zlib": "*"
     },
+    "suggest": {
+        "ext-fileinfo": "Needed to set correct MediaType in storage"
+    },
     "autoload": {
         "psr-4": {
             "Flownative\\Google\\CloudStorage\\": "Classes"


### PR DESCRIPTION
When uploading a resource to GCS storage the Content-Type is explicitly
defined in metadata options.

```
'metadata' => [
    'contentType' => $resource->getMediaType()
]
```

However `getMediaType()` is always returning the fallback value
`application/octet-stream` as it's logic is based on using the filename
to determine the Content-Type. At this point the filename consists only
of a sha1 or a random value.

PHP's fileinfo extension has functions to detect a Content-Type based on
file content.

This change uses `mime_content_type()` and `finfo_*()` functions (if these
are installed) to detect the Content-Type.