### PR TITLE
Avoid array_merge in loop in getObjects()

### DIFF
--- a/Classes/GcsStorage.php
+++ b/Classes/GcsStorage.php
@@ -371,10 +371,10 @@ class GcsStorage implements WritableStorageInterface
     {
         $objects = [];
         foreach ($this->resourceManager->getCollectionsByStorage($this) as $collection) {
-            /** @noinspection SlowArrayOperationsInLoopInspection */
-            $objects = array_merge($objects, $this->getObjectsByCollection($collection));
+            $objects[] = $this->getObjectsByCollection($collection);
         }
-        return $objects;
+
+        return array_merge([], ...$objects); // the empty array covers cases when no loops were made
     }
 
     /**


### PR DESCRIPTION
See https://github.com/kalessil/phpinspectionsea/blob/master/docs/performance.md#slow-array-function-used-in-loop