### PR TITLE
Re-introduce missing MD5 hash for Flow 6.x and earlier

### DIFF
--- a/Classes/GcsStorage.php
+++ b/Classes/GcsStorage.php
@@ -234,6 +234,11 @@ class GcsStorage implements WritableStorageInterface
         $resource->setCollectionName($collectionName);
         $resource->setSha1($sha1Hash);
 
+        # Provide compatibility with Flow 6.x and earlier:
+        if (method_exists($resource, 'setMd5')) {
+            $resource->setMd5(md5($content));
+        }
+        
         $this->getCurrentBucket()->upload($content, [
             'name' => $this->keyPrefix . $sha1Hash,
             'metadata' => [


### PR DESCRIPTION
An addendum to the fix for #25 in  b86adbe.