### PR TITLE
Adjust dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
         "MIT"
     ],
     "require": {
-        "neos/flow": "^5.2 || ^6.0 || ^7.0",
-        "google/cloud-storage": "1.1.*",
+        "neos/flow": "^6.0 || ^7.0",
+        "google/cloud-storage": "^1.1",
         "ext-json": "*",
         "ext-pdo": "*",
         "ext-zlib": "*"


### PR DESCRIPTION
This allows more current versions of google/cloud-storage and drops
support for Flow 5.x / Neos 4.x.