### PR TITLE
Fix "one-bucket" detection in publishResource()

### DIFF
--- a/Classes/GcsTarget.php
+++ b/Classes/GcsTarget.php
@@ -20,7 +20,6 @@ use Google\Cloud\Storage\Bucket;
 use Google\Cloud\Storage\StorageClient;
 use Google\Cloud\Storage\StorageObject;
 use GuzzleHttp\Psr7\Uri;
-use Neos\Error\Messages\Error;
 use Neos\Error\Messages\Message;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Log\Utility\LogEnvironment;
@@ -40,7 +39,6 @@ use Psr\Log\LoggerInterface;
  */
 class GcsTarget implements TargetInterface
 {
-
     /**
      * Name which identifies this resource target
      *

--- a/Classes/GcsTarget.php
+++ b/Classes/GcsTarget.php
@@ -447,7 +447,7 @@ class GcsTarget implements TargetInterface
     public function publishResource(PersistentResource $resource, CollectionInterface $collection): void
     {
         $storage = $collection->getStorage();
-        if ($storage instanceof GcsStorage && $storage->getBucketName() === $this->bucketName) {
+        if ($this->isOneBucketSetup($collection)) {
             $updated = false;
             $retries = 0;
             while (!$updated) {


### PR DESCRIPTION
In a "one-bucket" setup publishing can be "skipped", when the
`keyPrefix` of storage and target is the same (as the object is
already present in the one bucket being used.)

The check in `isOneBucketSetup()` did that check, but there was
another check for a "one-bucket" setup in `publishFile()` that did not
use that method, leading to the check for the `keyPrefix` not being
done.

Fixes https://github.com/flownative/flow-google-cloudstorage/issues/17