### PR TITLE
Raise minimum requirements to PHP 8 and Flow 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
         "MIT"
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
-        "neos/flow": "^6.3 || ^7.0 || ^8.0",
+        "php": "^8.0",
+        "neos/flow": "^7.0 || ^8.0",
         "google/cloud-storage": "^1.1",
         "ext-json": "*",
         "ext-pdo": "*",


### PR DESCRIPTION
This package now requires at least PHP 8.0 and therefore also at least Flow 7.0 in order to work.

#41