### PR TITLE
Introduce onPublish() to satisfy Flow 9 interface

### DIFF
--- a/Classes/GcsTarget.php
+++ b/Classes/GcsTarget.php
@@ -424,6 +424,16 @@ class GcsTarget implements TargetInterface
     }
 
     /**
+     * Satisfy the TargetInterface
+     *
+     * @param \Closure $callback
+     * @return void
+     */
+    public function onPublish(\Closure $callback): void
+    {
+    }
+
+    /**
      * Returns the web accessible URI pointing to the given static resource
      *
      * @param string $relativePathAndFilename Relative path and filename of the static resource


### PR DESCRIPTION
The TargetInterface in Flow 9 was extended by a new method "onPublish()". The GcsTarget class now implements that method in order to satisfy the new interface.

See also: https://github.com/neos/flow-development-collection/pull/3229