### PR TITLE
Introduce new `flowBaseUri` placeholder for URI pattern

### DIFF
--- a/Classes/GcsTarget.php
+++ b/Classes/GcsTarget.php
@@ -22,6 +22,7 @@ use Google\Cloud\Storage\StorageObject;
 use GuzzleHttp\Psr7\Uri;
 use Neos\Error\Messages\Message;
 use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Http\BaseUriProvider;
 use Neos\Flow\Log\Utility\LogEnvironment;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\ResourceManagement\CollectionInterface;
@@ -171,6 +172,12 @@ class GcsTarget implements TargetInterface
      * @var ObjectManagerInterface
      */
     protected $objectManager;
+
+    /**
+     * @Flow\Inject
+     * @var BaseUriProvider
+     */
+    protected $baseUriProvider;
 
     /**
      * Constructor
@@ -559,6 +566,7 @@ class GcsTarget implements TargetInterface
 
         $variables = [
             '{baseUri}' => $baseUri,
+            '{flowBaseUri}' => (string)$this->baseUriProvider->getConfiguredBaseUriOrFallbackToCurrentRequest(),
             '{bucketName}' => $this->bucketName,
             '{keyPrefix}' => $this->keyPrefix,
             '{sha1}' => $resource->getSha1(),

--- a/README.md
+++ b/README.md
@@ -262,19 +262,20 @@ a file stored in the Storage bucket using the given SHA1.
 You can tell the Target to render URIs like these by defining a pattern with placeholders:
 
 ```yaml
-      targets:
-        googlePersistentResourcesTarget:
-          target: 'Flownative\Google\CloudStorage\GcsTarget'
-          targetOptions:
-            bucket: 'flownativecom.flownative.cloud'
-            baseUri: 'https://assets.flownative.com/'
-            persistentResourceUris:
-              pattern: '{baseUri}{sha1}/{filename}'
+targets:
+  googlePersistentResourcesTarget:
+    target: 'Flownative\Google\CloudStorage\GcsTarget'
+    targetOptions:
+      bucket: 'flownativecom.flownative.cloud'
+      baseUri: 'https://assets.flownative.com/'
+      persistentResourceUris:
+        pattern: '{baseUri}{sha1}/{filename}'
 ```
 
 The possible placeholders are:
 
 - `{baseUri}` The base URI as defined in the target options
+- `{flowBaseUri}` The base URI as configured in or detected by Flow
 - `{bucketName}` The target's bucket name
 - `{keyPrefix}` The target's configured key prefix
 - `{sha1}` The resource's SHA1


### PR DESCRIPTION
The new placeholder allows to easily use the base URI detected by Flow for the URI of persistent resources:

```yaml
targets:
  googlePersistentResourcesTarget:
    target: 'Flownative\Google\CloudStorage\GcsTarget'
    targetOptions:
      bucket: 'flownativecom.flownative.cloud'
      persistentResourceUris:
        pattern: '{flowBaseUri}assets/{sha1}/{filename}'
```

This will use the base URI configured in Flow or the one detected from the current HTTP request (see `Neos\Flow\Http\BaseUriProvider` class).