### PR TITLE
Update version constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,9 @@
         "MIT"
     ],
     "require": {
-        "php": "8.0.* || 8.1.* || 8.2.* || 8.3.*",
-        "neos/flow": "^7.0 || ^8.0 || 9.0.*",
-        "google/cloud-storage": "^1.1",
+        "php": "^8.1",
+        "neos/flow": "^8.0 || 9.0.*",
+        "google/cloud-storage": "^1.40",
         "ext-json": "*",
         "ext-pdo": "*",
         "ext-zlib": "*"


### PR DESCRIPTION
- allow PHP 8.4
- no longer allow Flow 7
- raise minimum google/cloud-storage to 1.40