### PR TITLE
Allow Neos / Flow 9.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "neos/flow": "^8.0 || 9.0.*",
+        "neos/flow": "^8.0 || ^9.0",
         "google/cloud-storage": "^1.40",
         "ext-json": "*",
         "ext-pdo": "*",


### PR DESCRIPTION
Not sure why the dependency was so narrow before.